### PR TITLE
Separate elements expected in a scenario from ones described in the task

### DIFF
--- a/acceptance-criteria/bdd-shape-constraints.ttl
+++ b/acceptance-criteria/bdd-shape-constraints.ttl
@@ -70,16 +70,16 @@ bdd:OfScenarioShape
   sh:nodeKind sh:IRI ;
   sh:minCount 1 .
 
-# A ScenarioTaskVariable must be associated with 1 or more Scenario
-bdd:ScenarioTaskVariableShape
+# A ScenarioVariable must be associated with 1 or more Scenario
+bdd:ScenarioVariableShape
   a sh:NodeShape ;
-  sh:targetClass bdd:ScenarioTaskVariable ;
+  sh:targetClass bdd:ScenarioVariable ;
   sh:property bdd:OfScenarioShape .
 bdd:OfVariableShape
   a sh:PropertyShape ;
-  sh:description ":of-variable must link to at least 1 :ScenarioTaskVariable" ;
+  sh:description ":of-variable must link to at least 1 :ScenarioVariable" ;
   sh:path bdd:of-variable ;
-  sh:class bdd:ScenarioTaskVariable ;
+  sh:class bdd:ScenarioVariable ;
   sh:nodeKind sh:IRI ;
   sh:minCount 1 .
 

--- a/acceptance-criteria/bdd-shape-constraints.ttl
+++ b/acceptance-criteria/bdd-shape-constraints.ttl
@@ -70,16 +70,16 @@ bdd:OfScenarioShape
   sh:nodeKind sh:IRI ;
   sh:minCount 1 .
 
-# A ScenarioVariable must be associated with 1 or more Scenario
-bdd:ScenarioVariableShape
+# A ScenarioTaskVariable must be associated with 1 or more Scenario
+bdd:ScenarioTaskVariableShape
   a sh:NodeShape ;
-  sh:targetClass bdd:ScenarioVariable ;
+  sh:targetClass bdd:ScenarioTaskVariable ;
   sh:property bdd:OfScenarioShape .
 bdd:OfVariableShape
   a sh:PropertyShape ;
-  sh:description ":of-variable must link to at least 1 :ScenarioVariable" ;
+  sh:description ":of-variable must link to at least 1 :ScenarioTaskVariable" ;
   sh:path bdd:of-variable ;
-  sh:class bdd:ScenarioVariable ;
+  sh:class bdd:ScenarioTaskVariable ;
   sh:nodeKind sh:IRI ;
   sh:minCount 1 .
 

--- a/acceptance-criteria/bdd.json
+++ b/acceptance-criteria/bdd.json
@@ -18,6 +18,10 @@
 
         "WhenEvent": { "@id": "bdd:WhenEvent" },
 
+        "ScenarioHasObjects": { "@id": "bdd:ScenarioHasObjects" },
+        "ScenarioHasAgents": { "@id": "bdd:ScenarioHasAgents" },
+        "has-background": { "@id": "bdd:has-background", "@type": "@id" },
+
         "ScenarioTaskVariable": { "@id": "bdd:ScenarioTaskVariable" },
         "of-variable": { "@id": "bdd:of-variable", "@type": "@id" },
 

--- a/acceptance-criteria/bdd.json
+++ b/acceptance-criteria/bdd.json
@@ -11,16 +11,22 @@
         "when": { "@id": "bdd:when", "@type": "@id" },
         "then": { "@id": "bdd:then", "@type": "@id" },
 
+        "ScenarioTemplate": { "@id": "bdd:ScenarioTemplate" },
+        "of-template": { "@id": "bdd:of-template", "@type": "@id" },
+
+        "ScenarioVariant": { "@id": "bdd:ScenarioVariant" },
+
         "GivenClause": { "@id": "bdd:GivenClause" },
         "WhenClause": { "@id": "bdd:WhenClause" },
         "ThenClause": { "@id": "bdd:ThenClause" },
         "of-clause": { "@id": "bdd:of-clause", "@type": "@id" },
+        "has-clause": { "@id": "bdd:has-clause", "@type": "@id" },
 
         "WhenEvent": { "@id": "bdd:WhenEvent" },
 
-        "ScenarioHasObjects": { "@id": "bdd:ScenarioHasObjects" },
-        "ScenarioHasAgents": { "@id": "bdd:ScenarioHasAgents" },
-        "has-background": { "@id": "bdd:has-background", "@type": "@id" },
+        "SceneHasObjects": { "@id": "bdd:SceneHasObjects" },
+        "SceneHasAgents": { "@id": "bdd:SceneHasAgents" },
+        "has-in-scene": { "@id": "bdd:has-in-scene", "@type": "@id" },
 
         "ScenarioTaskVariable": { "@id": "bdd:ScenarioTaskVariable" },
         "of-variable": { "@id": "bdd:of-variable", "@type": "@id" },

--- a/acceptance-criteria/bdd.json
+++ b/acceptance-criteria/bdd.json
@@ -22,7 +22,7 @@
         "ScenarioHasAgents": { "@id": "bdd:ScenarioHasAgents" },
         "has-background": { "@id": "bdd:has-background", "@type": "@id" },
 
-        "ScenarioVariable": { "@id": "bdd:ScenarioVariable" },
+        "ScenarioTaskVariable": { "@id": "bdd:ScenarioTaskVariable" },
         "of-variable": { "@id": "bdd:of-variable", "@type": "@id" },
 
         "TimeConstraint": { "@id": "bdd:TimeConstraint" },

--- a/acceptance-criteria/bdd.json
+++ b/acceptance-criteria/bdd.json
@@ -18,7 +18,7 @@
 
         "WhenEvent": { "@id": "bdd:WhenEvent" },
 
-        "ScenarioVariable": { "@id": "bdd:ScenarioVariable" },
+        "ScenarioTaskVariable": { "@id": "bdd:ScenarioTaskVariable" },
         "of-variable": { "@id": "bdd:of-variable", "@type": "@id" },
 
         "TimeConstraint": { "@id": "bdd:TimeConstraint" },

--- a/acceptance-criteria/bdd.json
+++ b/acceptance-criteria/bdd.json
@@ -22,7 +22,7 @@
         "ScenarioHasAgents": { "@id": "bdd:ScenarioHasAgents" },
         "has-background": { "@id": "bdd:has-background", "@type": "@id" },
 
-        "ScenarioTaskVariable": { "@id": "bdd:ScenarioTaskVariable" },
+        "ScenarioVariable": { "@id": "bdd:ScenarioVariable" },
         "of-variable": { "@id": "bdd:of-variable", "@type": "@id" },
 
         "TimeConstraint": { "@id": "bdd:TimeConstraint" },

--- a/environment.json
+++ b/environment.json
@@ -3,10 +3,13 @@
         "env": "https://hbrs-sesame.github.io/metamodels/environment#",
 
         "Object": { "@id": "env:Object" },
+        "of-object": { "@id": "env:of-object", "@type": "@id" },
         "has-object": { "@id": "env:has-object", "@type": "@id" },
 
         "Workspace": { "@id": "env:Workspace" },
         "of-workspace": { "@id": "env:of-workspace", "@type": "@id" },
-        "has-workspace": { "@id": "env:has-workspace", "@type": "@id" }
+        "has-workspace": { "@id": "env:has-workspace", "@type": "@id" },
+
+        "RigidObject": { "@id": "env:RigidObject" }
     }
 }

--- a/geometry/extensions.json
+++ b/geometry/extensions.json
@@ -1,0 +1,7 @@
+{
+    "@context": {
+        "geom": "https://hbrs-sesame.github.io/metamodels/geometry#",
+
+        "PoseFromPositionOrientation": { "@id": "geom:PoseFromPositionOrientation" }
+    }
+}

--- a/simulation/simulation.json
+++ b/simulation/simulation.json
@@ -1,0 +1,11 @@
+{
+    "@context": {
+        "sim": "https://hbrs-sesame.github.io/metamodels/simulation#",
+
+        "SimulatedObject": { "@id": "sim:SimulatedObject" },
+        "has-shape": { "@id": "sim:has-shape", "@type": "@id" },
+        "has-attribute": { "@id": "sim:has-attribute", "@type": "@id" },
+
+        "ShapeModel": { "@id":"sim:ShapeModel" }
+    }
+}

--- a/task.json
+++ b/task.json
@@ -2,6 +2,9 @@
     "@context": {
         "task": "https://hbrs-sesame.github.io/metamodels/task#",
 
+        "Task": { "@id": "task:Task" },
+        "of-task": { "@id": "task:of-task", "@type": "@id" },
+
         "Variation": { "@id": "task:Variation" },
         "has-variation": { "@id": "task:has-variation", "@type": "@id" },
         "can-be": { "@id": "task:can-be", "@type": "@id" }

--- a/variation/probability.json
+++ b/variation/probability.json
@@ -1,0 +1,28 @@
+{
+    "@context": {
+        "xsd": "http://www.w3.org/2001/XMLSchema#",
+        "prob": "https://hbrs-sesame.github.io/metamodels/variation/probability#",
+        "Distribution": { "@id": "prob:Distribution" },
+
+        "Discrete": { "@id": "prob:Discrete" },
+        "Continuous": { "@id": "prob:Continuous" },
+
+        "dimension": { "@id": "prob:dimension", "@type": "xsd:positiveInteger" },
+
+        "Normal": { "@id": "prob:Normal" },
+        "mean": { "@id": "prob:mean", "@type": "xsd:decimal" },
+        "std": { "@id": "prob:standard-deviation", "@type": "xsd:decimal" },
+
+        "Uniform": { "@id": "prob:Uniform" },
+        "lower": { "@id": "prob:lower-bound", "@container": "@list" },
+        "upper": { "@id": "prob:upper-bound", "@container": "@list" },
+
+        "UniformRotation": { "@id": "prob:UniformRotation" },
+
+        "Categorical": { "@id": "prob:Categorical" },
+        "event-probability": { "@id": "prob:event-probability", "@type": "xsd:decimal", "@container": "@list" },
+
+        "SampledQuantity": { "@id": "prob:SampledQuantity" },
+        "from-distribution": { "@id": "prob:from-distribution", "@type": "@id" }
+    }
+}


### PR DESCRIPTION
There is a distinction with objects expected in a scene and objects which are part of a task. For instance, when grasping from a cluster, there would be multiple objects expected but only one "target object." This PR includes the following changes:
* Add `ScenarioTaskVariable` for describing elements referred to by some task specification. Instances of this concept can be referred to by BDD clauses or by `TaskVariation` for introducing variations to the scenario.
* Add missing `ScenarioVariant` concept
* Add `ScenarioTemplate` for better reuse of BDD templates
* Add simple concepts for specifying probabilities, geometry, and shapes, which can be used for generating concrete quantities in simulation